### PR TITLE
Fix 3 dead neptune.ai blog links in data-science.md

### DIFF
--- a/data-science.md
+++ b/data-science.md
@@ -85,10 +85,10 @@ MLops overview: https://github.com/visenger/awesome-mlops
 
 - mlFlow
 - https://docs.bentoml.org
-- https://neptune.ai/blog/experiment-management
-- https://neptune.ai/blog/mlops-what-it-is-why-it-matters-and-how-to-implement-it-from-a-data-scientist-perspective
+- https://web.archive.org/web/20251012093249/https://neptune.ai/blog/experiment-management
+- https://web.archive.org/web/20211009043527/https://neptune.ai/blog/mlops-what-it-is-why-it-matters-and-how-to-implement-it-from-a-data-scientist-perspective
 - https://towardsdatascience.com/machine-learning-experiment-tracking-93b796e501b0
-- https://neptune.ai/blog/machine-learning-model-management
+- https://web.archive.org/web/20251005125220/https://neptune.ai/blog/machine-learning-model-management
 
 ## bayesian analyses
 


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 3 dead links in `data-science.md`, pointing them to Wayback Machine snapshots of the original articles. Note: for the *mlops-what-it-is…* URL the last clean capture dates to 2021 (that URL appears to have been renamed/redirected long before the acquisition); the snapshot preserves the content that was originally linked.
All archive links are pinned to the last working (HTTP 200) Wayback capture before the redirect took effect.